### PR TITLE
[feature/todo to main] - feat: Enhance Teams notifications with scalable templates for PR reviews and daily status updates

### DIFF
--- a/.github/workflows/code-review-agent.lock.yml
+++ b/.github/workflows/code-review-agent.lock.yml
@@ -28,7 +28,7 @@
 #     - ./shared/teams-webhook.md
 #     - ./shared/templates/pr-review-template.md
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"ae36be4deb37c823a5bc9c11c50d2b8539352ac9362e7dd3d0062ce6433681d6","compiler_version":"v0.47.2"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"8d5a30018cd540ffcd7a7621ebf77f89850f45a7e9a3b52d52d3e951baab540e","compiler_version":"v0.47.2"}
 
 name: "Code Review Agent - Automatic PR Analyzer"
 "on":
@@ -1368,55 +1368,83 @@ jobs:
 
               core.info(`Sending Teams notification for PR #${prNumber} (type=${messageType})`);
 
-              // Choose theme and titles based on message type
-              let themeColor = '0078d4';
-              let activityTitle = 'Pull Request Raised';
-              let summaryText = 'Pull Request Raised';
+              // Build payload using templates per message type for scalability
+              const templates = {
+                pr_review: {
+                  themeColor: '0078d4',
+                  summary: 'Pull Request Raised',
+                  activityTitle: 'Pull Request Raised',
+                  buildSections: (it) => {
+                    // Use formatted critical comments (normalize bullets)
+                    let formattedCritical = 'No critical issues found.';
+                    if (criticalComments && criticalComments.trim()) {
+                      const lines = criticalComments.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+                      if (lines.length > 1) {
+                        const normalized = lines.map(l => l.replace(/^[\-\*•\s]+/, '').trim()).filter(Boolean);
+                        if (normalized.length > 0) formattedCritical = normalized.map(l => `- ${l}`).join('\n');
+                      } else {
+                        formattedCritical = '```\n' + criticalComments.trim() + '\n```';
+                      }
+                    }
 
-              if (messageType === 'security') {
-                themeColor = 'd33d3d';
-                activityTitle = 'Security Report';
-                summaryText = 'Security Scan Results';
-              } else if (messageType === 'daily_status') {
-                themeColor = '28a745';
-                activityTitle = 'Daily Status Update';
-                summaryText = 'Daily Status';
-              }
+                    const header = `**@${prAuthor}** opened PR [#${prNumber}](${prUrl}) - **${prTitle}**`;
+                    const details = `**Files Changed:** ${filesChanged}\n\n**Summary:** ${plainSummary}`;
+                    const criticalBlock = `**Critical Comments:**\n${formattedCritical}`;
 
-              // Construct main text including summary and critical comments
-              // Format critical comments: bullets if multiple lines, otherwise a fenced code block
-              let formattedCritical = 'No critical issues found.';
-              if (criticalComments && criticalComments.trim()) {
-                const lines = criticalComments.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
-                if (lines.length > 1) {
-                  formattedCritical = lines.map(l => `- ${l}`).join('\n');
-                } else {
-                  formattedCritical = '```\n' + criticalComments.trim() + '\n```';
-                }
-              }
-
-              const mainText = `Kindly note, **@${prAuthor}** has raised PR #${prNumber} - ${prTitle} targeting **${targetBranch}** branch. Please review.\n\n**Files Changed:** ${filesChanged}\n\n**Summary:** ${plainSummary}\n\n**Critical Comments:**\n${formattedCritical}`;
-
-              // Construct Teams MessageCard payload
-              const payload = {
-                "@type": "MessageCard",
-                "@context": "http://schema.org/extensions",
-                "themeColor": themeColor,
-                "summary": summaryText,
-                "sections": [{
-                  "activityTitle": activityTitle,
-                  "activitySubtitle": "[Auto-generated message]",
-                  "activityImage": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
-                  "text": mainText,
-                  "markdown": true
-                }],
-                "potentialAction": [{
-                  "@type": "OpenUri",
-                  "name": "View Pull Request",
-                  "targets": [{
-                    "os": "default",
-                    "uri": prUrl
+                    return [{
+                      activityTitle: templates.pr_review.activityTitle,
+                      activitySubtitle: '[Auto-generated message]',
+                      activityImage: 'https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png',
+                      text: `${header}\n\n${details}\n\n${criticalBlock}`,
+                      markdown: true
+                    }];
+                  }
+                },
+                security: {
+                  themeColor: 'd33d3d',
+                  summary: 'Security Scan Results',
+                  activityTitle: 'Security Report',
+                  buildSections: (it) => [{
+                    activityTitle: 'Security Report',
+                    activitySubtitle: '[Auto-generated message]',
+                    activityImage: 'https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png',
+                    text: `**Summary:** ${plainSummary}\n\n**Details:**\n${criticalComments || 'No critical issues found.'}`,
+                    markdown: true
                   }]
+                },
+                daily_status: {
+                  themeColor: '28a745',
+                  summary: 'Daily Status',
+                  activityTitle: 'Daily Status Update',
+                  buildSections: (it) => {
+                    const total = it.total_prs || '0';
+                    const prsByAuthor = it.prs_by_author || item.prs_by_author || '';
+                    const summaryText = plainSummary || '';
+                    const text = `**Summary:** ${summaryText}\n\n**Total PRs:** ${total}\n\n${prsByAuthor}`.trim();
+                    return [{
+                      activityTitle: 'Daily Status Update',
+                      activitySubtitle: '[Auto-generated message]',
+                      activityImage: 'https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png',
+                      text,
+                      markdown: true
+                    }];
+                  }
+                }
+              };
+
+              const tpl = templates[messageType] || templates.pr_review;
+              const sections = tpl.buildSections(item);
+
+              const payload = {
+                '@type': 'MessageCard',
+                '@context': 'http://schema.org/extensions',
+                themeColor: tpl.themeColor,
+                summary: tpl.summary,
+                sections,
+                potentialAction: [{
+                  '@type': 'OpenUri',
+                  name: 'View Pull Request',
+                  targets: [{ os: 'default', uri: prUrl }]
                 }]
               };
 

--- a/.github/workflows/daily-activity-report.lock.yml
+++ b/.github/workflows/daily-activity-report.lock.yml
@@ -25,7 +25,12 @@
 # repository activity including issues, pull requests, commits, discussions,
 # and releases to generate comprehensive daily reports delivered as GitHub issues.
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"d8f3dfdde28311850652467f34acaa1ada24dd399fa16ffdca12a0598615ab2d","compiler_version":"v0.47.2"}
+# Resolved workflow manifest:
+#   Imports:
+#     - ./shared/teams-webhook.md
+#     - ./shared/templates/daily-status-template.md
+#
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"047cdc6776668ae949469d076ac58b2f304655f7d2734310407017f1f16cc094","compiler_version":"v0.47.2"}
 
 name: "Daily Repository Activity Report"
 "on":
@@ -160,6 +165,12 @@ jobs:
           GH_AW_PROMPT_EOF
           cat << 'GH_AW_PROMPT_EOF' >> "$GH_AW_PROMPT"
           </system>
+          GH_AW_PROMPT_EOF
+          cat << 'GH_AW_PROMPT_EOF' >> "$GH_AW_PROMPT"
+          {{#runtime-import ./shared/teams-webhook.md}}
+          GH_AW_PROMPT_EOF
+          cat << 'GH_AW_PROMPT_EOF' >> "$GH_AW_PROMPT"
+          {{#runtime-import ./shared/templates/daily-status-template.md}}
           GH_AW_PROMPT_EOF
           cat << 'GH_AW_PROMPT_EOF' >> "$GH_AW_PROMPT"
           {{#runtime-import .github/workflows/daily-activity-report.md}}
@@ -350,51 +361,10 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > /opt/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_EOF'
-          {"create_issue":{"max":1},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
+          {"missing_data":{},"missing_tool":{},"noop":{"max":1},"teams-notify":{"description":"Send notification to Microsoft Teams channel","inputs":{"critical_comments":{"default":null,"description":"Critical reviewer comments or 'No critical issues found.'","required":false,"type":"string"},"files_changed":{"default":null,"description":"Number of files changed","required":false,"type":"string"},"message_type":{"default":null,"description":"Template type for Teams message (pr_review|security|daily_status)","required":false,"type":"string"},"plain_summary":{"default":null,"description":"Plain-language 2-3 sentence summary to show in the message","required":false,"type":"string"},"pr_author":{"default":null,"description":"Pull request author username","required":true,"type":"string"},"pr_number":{"default":null,"description":"Pull request number","required":true,"type":"string"},"pr_title":{"default":null,"description":"Pull request title","required":true,"type":"string"},"pr_url":{"default":null,"description":"Full URL to the pull request","required":true,"type":"string"},"target_branch":{"default":null,"description":"Target branch (develop/main)","required":true,"type":"string"}},"output":"Teams notification sent successfully!"}}
           GH_AW_SAFE_OUTPUTS_CONFIG_EOF
           cat > /opt/gh-aw/safeoutputs/tools.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_EOF'
           [
-            {
-              "description": "Create a new GitHub issue for tracking bugs, feature requests, or tasks. Use this for actionable work items that need assignment, labeling, and status tracking. For reports, announcements, or status updates that don't require task tracking, use create_discussion instead. CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[daily-report] \". Labels [report daily-activity] will be automatically added.",
-              "inputSchema": {
-                "additionalProperties": false,
-                "properties": {
-                  "body": {
-                    "description": "Detailed issue description in Markdown. Do NOT repeat the title as a heading since it already appears as the issue's h1. Include context, reproduction steps, or acceptance criteria as appropriate.",
-                    "type": "string"
-                  },
-                  "labels": {
-                    "description": "Labels to categorize the issue (e.g., 'bug', 'enhancement'). Labels must exist in the repository.",
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "parent": {
-                    "description": "Parent issue number for creating sub-issues. This is the numeric ID from the GitHub URL (e.g., 42 in github.com/owner/repo/issues/42). Can also be a temporary_id (e.g., 'aw_abc123', 'aw_Test123') from a previously created issue in the same workflow run.",
-                    "type": [
-                      "number",
-                      "string"
-                    ]
-                  },
-                  "temporary_id": {
-                    "description": "Unique temporary identifier for referencing this issue before it's created. Format: 'aw_' followed by 3 to 8 alphanumeric characters (e.g., 'aw_abc1', 'aw_Test123'). Use '#aw_ID' in body text to reference other issues by their temporary_id; these are replaced with actual issue numbers after creation.",
-                    "pattern": "^aw_[A-Za-z0-9]{3,8}$",
-                    "type": "string"
-                  },
-                  "title": {
-                    "description": "Concise issue title summarizing the bug, feature, or task. The title appears as the main heading, so keep it brief and descriptive.",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "title",
-                  "body"
-                ],
-                "type": "object"
-              },
-              "name": "create_issue"
-            },
             {
               "description": "Report that a tool or capability needed to complete the task is not available, or share any information you deem important about missing functionality or limitations. Use this when you cannot accomplish what was requested because the required functionality is missing or access is restricted.",
               "inputSchema": {
@@ -463,44 +433,64 @@ jobs:
                 "type": "object"
               },
               "name": "missing_data"
+            },
+            {
+              "description": "Send notification to Microsoft Teams channel",
+              "inputSchema": {
+                "additionalProperties": false,
+                "properties": {
+                  "critical_comments": {
+                    "description": "Critical reviewer comments or 'No critical issues found.'",
+                    "type": "string"
+                  },
+                  "files_changed": {
+                    "description": "Number of files changed",
+                    "type": "string"
+                  },
+                  "message_type": {
+                    "description": "Template type for Teams message (pr_review|security|daily_status)",
+                    "type": "string"
+                  },
+                  "plain_summary": {
+                    "description": "Plain-language 2-3 sentence summary to show in the message",
+                    "type": "string"
+                  },
+                  "pr_author": {
+                    "description": "Pull request author username",
+                    "type": "string"
+                  },
+                  "pr_number": {
+                    "description": "Pull request number",
+                    "type": "string"
+                  },
+                  "pr_title": {
+                    "description": "Pull request title",
+                    "type": "string"
+                  },
+                  "pr_url": {
+                    "description": "Full URL to the pull request",
+                    "type": "string"
+                  },
+                  "target_branch": {
+                    "description": "Target branch (develop/main)",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "pr_author",
+                  "pr_number",
+                  "pr_title",
+                  "pr_url",
+                  "target_branch"
+                ],
+                "type": "object"
+              },
+              "name": "teams_notify"
             }
           ]
           GH_AW_SAFE_OUTPUTS_TOOLS_EOF
           cat > /opt/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_EOF'
           {
-            "create_issue": {
-              "defaultMax": 1,
-              "fields": {
-                "body": {
-                  "required": true,
-                  "type": "string",
-                  "sanitize": true,
-                  "maxLength": 65000
-                },
-                "labels": {
-                  "type": "array",
-                  "itemType": "string",
-                  "itemSanitize": true,
-                  "itemMaxLength": 128
-                },
-                "parent": {
-                  "issueOrPRNumber": true
-                },
-                "repo": {
-                  "type": "string",
-                  "maxLength": 256
-                },
-                "temporary_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "required": true,
-                  "type": "string",
-                  "sanitize": true,
-                  "maxLength": 128
-                }
-              }
-            },
             "missing_tool": {
               "defaultMax": 20,
               "fields": {
@@ -804,11 +794,9 @@ jobs:
       - agent
       - detection
       - safe_outputs
+      - teams_notify
     if: (always()) && (needs.agent.result != 'skipped')
     runs-on: ubuntu-slim
-    permissions:
-      contents: read
-      issues: write
     outputs:
       noop_message: ${{ steps.noop.outputs.noop_message }}
       tools_reported: ${{ steps.missing_tool.outputs.tools_reported }}
@@ -1000,9 +988,6 @@ jobs:
       - detection
     if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (needs.detection.outputs.success == 'true')
     runs-on: ubuntu-slim
-    permissions:
-      contents: read
-      issues: write
     timeout-minutes: 15
     env:
       GH_AW_ENGINE_ID: "copilot"
@@ -1034,7 +1019,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"labels\":[\"report\",\"daily-activity\"],\"max\":1,\"title_prefix\":\"[daily-report] \"},\"missing_data\":{},\"missing_tool\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"missing_data\":{},\"missing_tool\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1049,4 +1034,182 @@ jobs:
           name: safe-output-items
           path: /tmp/safe-output-items.jsonl
           if-no-files-found: warn
+
+  teams_notify:
+    needs:
+      - agent
+      - detection
+    if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (contains(needs.agent.outputs.output_types, 'teams_notify'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Download agent output artifact
+        continue-on-error: true
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        with:
+          name: agent-output
+          path: /opt/gh-aw/safe-jobs/
+      - name: Setup Safe Job Environment Variables
+        run: |
+          find "/opt/gh-aw/safe-jobs/" -type f -print
+          echo "GH_AW_AGENT_OUTPUT=/opt/gh-aw/safe-jobs/agent_output.json" >> "$GITHUB_ENV"
+      - name: Send Teams notification
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
+        with:
+          script: |
+            const fs = require('fs');
+            const webhookUrl = process.env.TEAMS_WEBHOOK_URL;
+            const outputFile = process.env.GH_AW_AGENT_OUTPUT;
+
+            // Validate webhook URL
+            if (!webhookUrl) {
+              core.setFailed('TEAMS_WEBHOOK_URL secret is not configured');
+              return;
+            }
+
+            // Check if running in staged mode
+            if (process.env.GH_AW_SAFE_OUTPUTS_STAGED === 'true') {
+              core.info('📋 Staged mode: Would send Teams notification');
+              await core.summary.addRaw('## Preview\n\nWould send Teams notification for PR').write();
+              return;
+            }
+
+            // Read agent output
+            if (!outputFile) {
+              core.info('No GH_AW_AGENT_OUTPUT found');
+              return;
+            }
+
+            const fileContent = fs.readFileSync(outputFile, 'utf8');
+            const agentOutput = JSON.parse(fileContent);
+
+            // Filter for teams-notify items (job name with dashes → underscores)
+            const items = agentOutput.items.filter(item => item.type === 'teams_notify');
+
+            if (items.length === 0) {
+              core.info('No teams_notify items found in agent output');
+              return;
+            }
+
+            // Process each notification
+            for (const item of items) {
+              const prNumber = item.pr_number || 'Unknown';
+              const prTitle = item.pr_title || 'No title';
+              const prAuthor = item.pr_author || 'Unknown';
+              const targetBranch = item.target_branch || 'Unknown';
+              const prUrl = item.pr_url || '';
+              const filesChanged = item.files_changed || '0';
+              const messageType = (item.message_type || 'pr_review').toLowerCase();
+              const plainSummary = item.plain_summary || '';
+              const criticalComments = item.critical_comments || 'No critical issues found.';
+
+              core.info(`Sending Teams notification for PR #${prNumber} (type=${messageType})`);
+
+              // Build payload using templates per message type for scalability
+              const templates = {
+                pr_review: {
+                  themeColor: '0078d4',
+                  summary: 'Pull Request Raised',
+                  activityTitle: 'Pull Request Raised',
+                  buildSections: (it) => {
+                    // Use formatted critical comments (normalize bullets)
+                    let formattedCritical = 'No critical issues found.';
+                    if (criticalComments && criticalComments.trim()) {
+                      const lines = criticalComments.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+                      if (lines.length > 1) {
+                        const normalized = lines.map(l => l.replace(/^[\-\*•\s]+/, '').trim()).filter(Boolean);
+                        if (normalized.length > 0) formattedCritical = normalized.map(l => `- ${l}`).join('\n');
+                      } else {
+                        formattedCritical = '```\n' + criticalComments.trim() + '\n```';
+                      }
+                    }
+
+                    const header = `**@${prAuthor}** opened PR [#${prNumber}](${prUrl}) - **${prTitle}**`;
+                    const details = `**Files Changed:** ${filesChanged}\n\n**Summary:** ${plainSummary}`;
+                    const criticalBlock = `**Critical Comments:**\n${formattedCritical}`;
+
+                    return [{
+                      activityTitle: templates.pr_review.activityTitle,
+                      activitySubtitle: '[Auto-generated message]',
+                      activityImage: 'https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png',
+                      text: `${header}\n\n${details}\n\n${criticalBlock}`,
+                      markdown: true
+                    }];
+                  }
+                },
+                security: {
+                  themeColor: 'd33d3d',
+                  summary: 'Security Scan Results',
+                  activityTitle: 'Security Report',
+                  buildSections: (it) => [{
+                    activityTitle: 'Security Report',
+                    activitySubtitle: '[Auto-generated message]',
+                    activityImage: 'https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png',
+                    text: `**Summary:** ${plainSummary}\n\n**Details:**\n${criticalComments || 'No critical issues found.'}`,
+                    markdown: true
+                  }]
+                },
+                daily_status: {
+                  themeColor: '28a745',
+                  summary: 'Daily Status',
+                  activityTitle: 'Daily Status Update',
+                  buildSections: (it) => {
+                    const total = it.total_prs || '0';
+                    const prsByAuthor = it.prs_by_author || item.prs_by_author || '';
+                    const summaryText = plainSummary || '';
+                    const text = `**Summary:** ${summaryText}\n\n**Total PRs:** ${total}\n\n${prsByAuthor}`.trim();
+                    return [{
+                      activityTitle: 'Daily Status Update',
+                      activitySubtitle: '[Auto-generated message]',
+                      activityImage: 'https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png',
+                      text,
+                      markdown: true
+                    }];
+                  }
+                }
+              };
+
+              const tpl = templates[messageType] || templates.pr_review;
+              const sections = tpl.buildSections(item);
+
+              const payload = {
+                '@type': 'MessageCard',
+                '@context': 'http://schema.org/extensions',
+                themeColor: tpl.themeColor,
+                summary: tpl.summary,
+                sections,
+                potentialAction: [{
+                  '@type': 'OpenUri',
+                  name: 'View Pull Request',
+                  targets: [{ os: 'default', uri: prUrl }]
+                }]
+              };
+
+              // Send to Teams webhook
+              try {
+                const response = await fetch(webhookUrl, {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json'
+                  },
+                  body: JSON.stringify(payload)
+                });
+
+                if (!response.ok) {
+                  const errorText = await response.text();
+                  core.setFailed(`Teams webhook failed (${response.status}): ${errorText}`);
+                  return;
+                }
+
+                core.info('✅ Teams notification sent successfully');
+                core.info(`PR #${prNumber} notification delivered`);
+
+              } catch (error) {
+                core.setFailed(`Failed to send Teams notification: ${error.message}`);
+                return;
+              }
+            }
 

--- a/.github/workflows/daily-activity-report.md
+++ b/.github/workflows/daily-activity-report.md
@@ -23,9 +23,6 @@ imports:
   - ./shared/teams-webhook.md
   - ./shared/templates/daily-status-template.md
 
-safe-outputs:
-  teams-notify: {}
-
 engine: copilot
 ---
 
@@ -162,9 +159,11 @@ Create a well-structured GitHub issue with the following format:
 4. **Send Daily Report to Teams**
   - Format the report following the structure above
   - Send the report to Microsoft Teams using the `teams-notify` safe-output and the `daily_status` template
-  - Required fields to include in the payload:
+  - Required fields to include in the payload (recommended):
     - `message_type`: `daily_status`
     - `plain_summary`: 2-3 sentence summary of the day's activity
+    - `total_prs`: total number of PRs raised today (number or string)
+    - `prs_by_author`: Markdown-formatted grouped list of PRs by username (see example below)
     - `critical_comments`: short list of urgent highlights or blockers (or `No critical issues found.`)
     - `details`: optional structured object with metrics (issues, prs, commits, etc.)
   - Example agent output item (the agent should emit an item of type `teams_notify`):
@@ -173,13 +172,15 @@ Create a well-structured GitHub issue with the following format:
 {
   "type": "teams_notify",
   "message_type": "daily_status",
-  "plain_summary": "Quiet day: 2 PRs opened, 1 merged. No major incidents.",
-  "critical_comments": "No critical issues found.",
-  "details": { "issues_opened": 2, "prs_merged": 1, "commits": 5 }
+  "plain_summary": "Moderate activity: 5 PRs opened, 2 merged. One PR needs urgent review.",
+  "total_prs": 5,
+  "prs_by_author": "**alice** (2 PRs)\n- [#423] Fix login validation — prevents 500 on empty input\n  - Files: src/auth.js, tests/auth.test.js\n- [#424] Add logout endpoint — short description\n**bob** (1 PR)\n- [#425] Upgrade deps — bump lodash and axios\n**carol** (2 PRs)\n- [#426] Improve caching — reduces DB load\n- [#427] Update docs — API examples",
+  "critical_comments": "- PR #426: Potential performance regression in cache layer\n- PR #423: Failing unit tests on CI",
+  "details": { "issues_opened": 1, "prs_opened": 5, "prs_merged": 2, "commits": 12 }
 }
 ```
 
-  - The imported `daily_status` template will format the Teams card and post to the configured channel.
+  - The imported `daily_status` template will format the Teams card and post to the configured channel. Ensure the agent populates `prs_by_author` as concise Markdown (1-2 bullets per PR plus optional 1-2 detail sub-bullets) so messages remain readable.
 
 ## Special Cases
 

--- a/.github/workflows/pr-security-review-with-teams.lock.yml
+++ b/.github/workflows/pr-security-review-with-teams.lock.yml
@@ -27,7 +27,7 @@
 #   Imports:
 #     - ./shared/teams-webhook.md
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"faed695ecd3f6ddb31a87aed2036db1bc57c2b59bea4aaee4214bcb915d81444","compiler_version":"v0.47.2"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"4f3b68e3ba7b5b38ed65f7d7327ccc4b113956e80999b6939593da3e53221141","compiler_version":"v0.47.2"}
 
 name: "PR Teams Notification"
 "on":
@@ -1150,44 +1150,83 @@ jobs:
 
               core.info(`Sending Teams notification for PR #${prNumber} (type=${messageType})`);
 
-              // Choose theme and titles based on message type
-              let themeColor = '0078d4';
-              let activityTitle = 'Pull Request Raised';
-              let summaryText = 'Pull Request Raised';
+              // Build payload using templates per message type for scalability
+              const templates = {
+                pr_review: {
+                  themeColor: '0078d4',
+                  summary: 'Pull Request Raised',
+                  activityTitle: 'Pull Request Raised',
+                  buildSections: (it) => {
+                    // Use formatted critical comments (normalize bullets)
+                    let formattedCritical = 'No critical issues found.';
+                    if (criticalComments && criticalComments.trim()) {
+                      const lines = criticalComments.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+                      if (lines.length > 1) {
+                        const normalized = lines.map(l => l.replace(/^[\-\*•\s]+/, '').trim()).filter(Boolean);
+                        if (normalized.length > 0) formattedCritical = normalized.map(l => `- ${l}`).join('\n');
+                      } else {
+                        formattedCritical = '```\n' + criticalComments.trim() + '\n```';
+                      }
+                    }
 
-              if (messageType === 'security') {
-                themeColor = 'd33d3d';
-                activityTitle = 'Security Report';
-                summaryText = 'Security Scan Results';
-              } else if (messageType === 'daily_status') {
-                themeColor = '28a745';
-                activityTitle = 'Daily Status Update';
-                summaryText = 'Daily Status';
-              }
+                    const header = `**@${prAuthor}** opened PR [#${prNumber}](${prUrl}) - **${prTitle}**`;
+                    const details = `**Files Changed:** ${filesChanged}\n\n**Summary:** ${plainSummary}`;
+                    const criticalBlock = `**Critical Comments:**\n${formattedCritical}`;
 
-              // Construct main text including summary and critical comments
-              const mainText = `Kindly note, **@${prAuthor}** has raised PR #${prNumber} - ${prTitle} targeting **${targetBranch}** branch. Please review.\n\n**Files Changed:** ${filesChanged}\n\n**Summary:** ${plainSummary}\n\n**Critical Comments:** ${criticalComments}`;
-
-              // Construct Teams MessageCard payload
-              const payload = {
-                "@type": "MessageCard",
-                "@context": "http://schema.org/extensions",
-                "themeColor": themeColor,
-                "summary": summaryText,
-                "sections": [{
-                  "activityTitle": activityTitle,
-                  "activitySubtitle": "[Auto-generated message]",
-                  "activityImage": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
-                  "text": mainText,
-                  "markdown": true
-                }],
-                "potentialAction": [{
-                  "@type": "OpenUri",
-                  "name": "View Pull Request",
-                  "targets": [{
-                    "os": "default",
-                    "uri": prUrl
+                    return [{
+                      activityTitle: templates.pr_review.activityTitle,
+                      activitySubtitle: '[Auto-generated message]',
+                      activityImage: 'https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png',
+                      text: `${header}\n\n${details}\n\n${criticalBlock}`,
+                      markdown: true
+                    }];
+                  }
+                },
+                security: {
+                  themeColor: 'd33d3d',
+                  summary: 'Security Scan Results',
+                  activityTitle: 'Security Report',
+                  buildSections: (it) => [{
+                    activityTitle: 'Security Report',
+                    activitySubtitle: '[Auto-generated message]',
+                    activityImage: 'https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png',
+                    text: `**Summary:** ${plainSummary}\n\n**Details:**\n${criticalComments || 'No critical issues found.'}`,
+                    markdown: true
                   }]
+                },
+                daily_status: {
+                  themeColor: '28a745',
+                  summary: 'Daily Status',
+                  activityTitle: 'Daily Status Update',
+                  buildSections: (it) => {
+                    const total = it.total_prs || '0';
+                    const prsByAuthor = it.prs_by_author || item.prs_by_author || '';
+                    const summaryText = plainSummary || '';
+                    const text = `**Summary:** ${summaryText}\n\n**Total PRs:** ${total}\n\n${prsByAuthor}`.trim();
+                    return [{
+                      activityTitle: 'Daily Status Update',
+                      activitySubtitle: '[Auto-generated message]',
+                      activityImage: 'https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png',
+                      text,
+                      markdown: true
+                    }];
+                  }
+                }
+              };
+
+              const tpl = templates[messageType] || templates.pr_review;
+              const sections = tpl.buildSections(item);
+
+              const payload = {
+                '@type': 'MessageCard',
+                '@context': 'http://schema.org/extensions',
+                themeColor: tpl.themeColor,
+                summary: tpl.summary,
+                sections,
+                potentialAction: [{
+                  '@type': 'OpenUri',
+                  name: 'View Pull Request',
+                  targets: [{ os: 'default', uri: prUrl }]
                 }]
               };
 

--- a/.github/workflows/shared/teams-webhook.md
+++ b/.github/workflows/shared/teams-webhook.md
@@ -100,44 +100,83 @@ safe-outputs:
 
                 core.info(`Sending Teams notification for PR #${prNumber} (type=${messageType})`);
 
-                // Choose theme and titles based on message type
-                let themeColor = '0078d4';
-                let activityTitle = 'Pull Request Raised';
-                let summaryText = 'Pull Request Raised';
+                // Build payload using templates per message type for scalability
+                const templates = {
+                  pr_review: {
+                    themeColor: '0078d4',
+                    summary: 'Pull Request Raised',
+                    activityTitle: 'Pull Request Raised',
+                    buildSections: (it) => {
+                      // Use formatted critical comments (normalize bullets)
+                      let formattedCritical = 'No critical issues found.';
+                      if (criticalComments && criticalComments.trim()) {
+                        const lines = criticalComments.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+                        if (lines.length > 1) {
+                          const normalized = lines.map(l => l.replace(/^[\-\*•\s]+/, '').trim()).filter(Boolean);
+                          if (normalized.length > 0) formattedCritical = normalized.map(l => `- ${l}`).join('\n');
+                        } else {
+                          formattedCritical = '```\n' + criticalComments.trim() + '\n```';
+                        }
+                      }
 
-                if (messageType === 'security') {
-                  themeColor = 'd33d3d';
-                  activityTitle = 'Security Report';
-                  summaryText = 'Security Scan Results';
-                } else if (messageType === 'daily_status') {
-                  themeColor = '28a745';
-                  activityTitle = 'Daily Status Update';
-                  summaryText = 'Daily Status';
-                }
+                      const header = `**@${prAuthor}** opened PR [#${prNumber}](${prUrl}) - **${prTitle}**`;
+                      const details = `**Files Changed:** ${filesChanged}\n\n**Summary:** ${plainSummary}`;
+                      const criticalBlock = `**Critical Comments:**\n${formattedCritical}`;
 
-                // Construct main text including summary and critical comments
-                const mainText = `Kindly note, **@${prAuthor}** has raised PR #${prNumber} - ${prTitle} targeting **${targetBranch}** branch. Please review.\n\n**Files Changed:** ${filesChanged}\n\n**Summary:** ${plainSummary}\n\n**Critical Comments:** ${criticalComments}`;
-
-                // Construct Teams MessageCard payload
-                const payload = {
-                  "@type": "MessageCard",
-                  "@context": "http://schema.org/extensions",
-                  "themeColor": themeColor,
-                  "summary": summaryText,
-                  "sections": [{
-                    "activityTitle": activityTitle,
-                    "activitySubtitle": "[Auto-generated message]",
-                    "activityImage": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
-                    "text": mainText,
-                    "markdown": true
-                  }],
-                  "potentialAction": [{
-                    "@type": "OpenUri",
-                    "name": "View Pull Request",
-                    "targets": [{
-                      "os": "default",
-                      "uri": prUrl
+                      return [{
+                        activityTitle: templates.pr_review.activityTitle,
+                        activitySubtitle: '[Auto-generated message]',
+                        activityImage: 'https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png',
+                        text: `${header}\n\n${details}\n\n${criticalBlock}`,
+                        markdown: true
+                      }];
+                    }
+                  },
+                  security: {
+                    themeColor: 'd33d3d',
+                    summary: 'Security Scan Results',
+                    activityTitle: 'Security Report',
+                    buildSections: (it) => [{
+                      activityTitle: 'Security Report',
+                      activitySubtitle: '[Auto-generated message]',
+                      activityImage: 'https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png',
+                      text: `**Summary:** ${plainSummary}\n\n**Details:**\n${criticalComments || 'No critical issues found.'}`,
+                      markdown: true
                     }]
+                  },
+                  daily_status: {
+                    themeColor: '28a745',
+                    summary: 'Daily Status',
+                    activityTitle: 'Daily Status Update',
+                    buildSections: (it) => {
+                      const total = it.total_prs || '0';
+                      const prsByAuthor = it.prs_by_author || item.prs_by_author || '';
+                      const summaryText = plainSummary || '';
+                      const text = `**Summary:** ${summaryText}\n\n**Total PRs:** ${total}\n\n${prsByAuthor}`.trim();
+                      return [{
+                        activityTitle: 'Daily Status Update',
+                        activitySubtitle: '[Auto-generated message]',
+                        activityImage: 'https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png',
+                        text,
+                        markdown: true
+                      }];
+                    }
+                  }
+                };
+
+                const tpl = templates[messageType] || templates.pr_review;
+                const sections = tpl.buildSections(item);
+
+                const payload = {
+                  '@type': 'MessageCard',
+                  '@context': 'http://schema.org/extensions',
+                  themeColor: tpl.themeColor,
+                  summary: tpl.summary,
+                  sections,
+                  potentialAction: [{
+                    '@type': 'OpenUri',
+                    name: 'View Pull Request',
+                    targets: [{ os: 'default', uri: prUrl }]
                   }]
                 };
 

--- a/.github/workflows/shared/templates/daily-status-template.md
+++ b/.github/workflows/shared/templates/daily-status-template.md
@@ -12,12 +12,25 @@ teams_template:
   activityTitle: 'Daily Status Update'
   summary: 'Daily Status'
   sections:
-    - name: summary
-      fields: [plain_summary]
-    - name: highlights
-      fields: [critical_comments]
+    - name: overview
+      fields: [plain_summary, total_prs]
+    - name: prs_by_author
+      # `prs_by_author` should be pre-formatted Markdown grouping PRs by author.
+      # Example:
+      # **alice** (2 PRs)
+      # - [#123] Fix login — brief one-line summary
+      #   - Files: src/auth.js, tests/auth.test.js
+      # - [#124] Add logout — brief one-line summary
+      # **bob** (1 PR)
+      # - [#125] Upgrade deps — brief one-line summary
+      fields: [prs_by_author]
 
 usage:
   - workflow: daily-status.md
     set: message_type: daily_status
-    provide: [plain_summary, critical_comments]
+    provide: [plain_summary, total_prs, prs_by_author]
+
+notes:
+  - `total_prs`: total number of PRs raised today (string or number)
+  - `prs_by_author`: Markdown-formatted grouped list of PRs by username. Each author group should include a one-line bullet per PR and optional sub-bullets with details (files changed, labels, short notes).
+  - Keep `prs_by_author` concise — use 1-2 bullets per PR and 1-2 sub-items for details.

--- a/.github/workflows/weekly-design-pattern-check.lock.yml
+++ b/.github/workflows/weekly-design-pattern-check.lock.yml
@@ -27,13 +27,12 @@
 #   Imports:
 #     - ../agents/design-pattern-suggester.agent.md
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"7c71a02ed7bb644ade2b40d1518737a96e65b1d309784546ce7c523b8b2202d8","compiler_version":"v0.47.2"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"b5a045153afb15871713fe4a9828051d350b943f1295a131edffeebed03b32ab","compiler_version":"v0.47.2"}
 
 name: "Weekly Design Pattern Check - Automated Architectural Analysis"
 "on":
   schedule:
-  - cron: "7 10 * * 6"
-    # Friendly format: weekly (scattered)
+  - cron: "0 0 * * 0"
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/weekly-security-check.lock.yml
+++ b/.github/workflows/weekly-security-check.lock.yml
@@ -27,13 +27,12 @@
 #   Imports:
 #     - ../agents/security-reviewer.agent.md
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"ea75dcfb90e904dc1d3338706c99a1f69a4c419941cfe69987b438e54921e73b","compiler_version":"v0.47.2"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"edf3e55e48b1a143bafd796aa1871ed2d6d6c95d89f53157ea08ed797f20a5e5","compiler_version":"v0.47.2"}
 
 name: "Weekly Security Check - Automated Security Analysis"
 "on":
   schedule:
-  - cron: "58 2 * * 4"
-    # Friendly format: weekly (scattered)
+  - cron: "0 0 * * 0"
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
## Summary
Refactors the Microsoft Teams notification logic across all workflow files from a flat if/else structure to a scalable template-based pattern (`templates` object with `buildSections` per message type). Additionally, the daily activity report workflow is extended to send Teams notifications with richer `prs_by_author` and `total_prs` data, and both weekly check schedules are unified to run on Sundays at midnight.

## Changes Made
- **`shared/teams-webhook.md`** — Core Teams webhook logic refactored to a `templates` dictionary keyed by `message_type` (`pr_review`, `security`, `daily_status`), each with its own `buildSections` factory for more composable card construction.
- **`code-review-agent.lock.yml`** — Compiled lock updated to reflect new template-based Teams notification logic.
- **`pr-security-review-with-teams.lock.yml`** — Same template-based refactor as above.
- **`daily-activity-report.md`** — Removed the `safe-outputs: teams-notify: {}` declaration (handled via imported `teams-webhook.md`); expanded Teams payload docs with `total_prs` and `prs_by_author` fields and a richer example.
- **`daily-activity-report.lock.yml`** — Added a new `teams_notify` job; removed `create_issue` safe-output and its related permissions/config; imported `teams-webhook.md` and `daily-status-template.md` at runtime.
- **`shared/templates/daily-status-template.md`** — Template updated with `total_prs` and `prs_by_author` sections, plus usage notes.
- **`weekly-design-pattern-check.lock.yml`** — Cron updated to `0 0 * * 0`.
- **`weekly-security-check.lock.yml`** — Cron updated to `0 0 * * 0`.

## Why This Change
The previous flat if/else approach for Teams message types was hard to extend. The template pattern makes adding new message types (e.g., `release`, `incident`) a matter of adding a single key to the `templates` object without modifying existing logic. The daily status report is enriched to give reviewers an at-a-glance view of who opened what PRs.

## Testing
- Verify Teams webhook fires correctly for `pr_review`, `security`, and `daily_status` message types.
- Confirm `daily-activity-report` sends Teams notification (and verify the `create_issue` removal is intentional).
- Manually trigger `weekly-design-pattern-check` and `weekly-security-check` workflows to confirm they no longer conflict.

## Checklist
- [ ] Code follows project standards
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Breaking changes noted (removal of `create_issue` from daily report)

> Generated by [Code Review Agent - Automatic PR Analyzer](https://github.com/meet-vaghasiya-simform/temp-pr-review-agent-testing/actions/runs/22307293225)